### PR TITLE
Generate static exercise README templates

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -1,0 +1,16 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -1,0 +1,49 @@
+# Bob
+
+Bob is a lackadaisical teenager. In conversation, his responses are very limited.
+
+Bob answers 'Sure.' if you ask him a question.
+
+He answers 'Whoa, chill out!' if you yell at him.
+
+He says 'Fine. Be that way!' if you address him without actually saying
+anything.
+
+He answers 'Whatever.' to anything else.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -1,0 +1,81 @@
+# Circular Buffer
+
+A circular buffer, cyclic buffer or ring buffer is a data structure that
+uses a single, fixed-size buffer as if it were connected end-to-end.
+
+A circular buffer first starts empty and of some predefined length. For
+example, this is a 7-element buffer:
+
+    [ ][ ][ ][ ][ ][ ][ ]
+
+Assume that a 1 is written into the middle of the buffer (exact starting
+location does not matter in a circular buffer):
+
+    [ ][ ][ ][1][ ][ ][ ]
+
+Then assume that two more elements are added — 2 & 3 — which get
+appended after the 1:
+
+    [ ][ ][ ][1][2][3][ ]
+
+If two elements are then removed from the buffer, the oldest values
+inside the buffer are removed. The two elements removed, in this case,
+are 1 & 2, leaving the buffer with just a 3:
+
+    [ ][ ][ ][ ][ ][3][ ]
+
+If the buffer has 7 elements then it is completely full:
+
+    [6][7][8][9][3][4][5]
+
+When the buffer is full an error will be raised, alerting the client
+that further writes are blocked until a slot becomes free.
+
+The client can opt to overwrite the oldest data with a forced write. In
+this case, two more elements — A & B — are added and they overwrite the
+3 & 4:
+
+    [6][7][8][9][A][B][5]
+
+Finally, if two elements are now removed then what would be returned is
+not 3 & 4 but 5 & 6 because A & B overwrote the 3 & the 4 yielding the
+buffer with:
+
+    [ ][7][8][9][A][B][ ]
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Circular_buffer](http://en.wikipedia.org/wiki/Circular_buffer)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -1,0 +1,105 @@
+# Crypto Square
+
+Implement the classic method for composing secret messages called a square code.
+
+Given an English text, output the encoded version of that text.
+
+First, the input is normalized: the spaces and punctuation are removed
+from the English text and the message is downcased.
+
+Then, the normalized characters are broken into rows.  These rows can be
+regarded as forming a rectangle when printed with intervening newlines.
+
+For example, the sentence
+
+> If man was meant to stay on the ground, god would have given us roots.
+
+is normalized to:
+
+> ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots
+
+The plaintext should be organized in to a rectangle.  The size of the
+rectangle (`r x c`) should be decided by the length of the message,
+such that `c >= r` and `c - r <= 1`, where `c` is the number of columns
+and `r` is the number of rows.
+
+Our normalized text is 54 characters long, dictating a rectangle with
+`c = 8` and `r = 7`:
+
+```plain
+ifmanwas
+meanttos
+tayonthe
+groundgo
+dwouldha
+vegivenu
+sroots
+```
+
+The coded message is obtained by reading down the columns going left to
+right.
+
+The message above is coded as:
+
+```plain
+imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
+```
+
+Output the encoded text in chunks.  Phrases that fill perfect squares
+`(r X r)` should be output in `r`-length chunks separated by spaces.
+Imperfect squares will have `n` empty spaces.  Those spaces should be distributed evenly across the last `n` rows.
+
+```plain
+imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau
+```
+
+Notice that were we to stack these, we could visually decode the
+cyphertext back in to the original message:
+
+```plain
+imtgdvs
+fearwer
+mayoogo
+anouuio
+ntnnlvt
+wttddes
+aohghn
+sseoau
+```
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -1,0 +1,50 @@
+# Difference Of Squares
+
+Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
+
+The square of the sum of the first ten natural numbers is
+(1 + 2 + ... + 10)² = 55² = 3025.
+
+The sum of the squares of the first ten natural numbers is
+1² + 2² + ... + 10² = 385.
+
+Hence the difference between the square of the sum of the first
+ten natural numbers and the sum of the squares of the first ten
+natural numbers is 3025 - 385 = 2640.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+Problem 6 at Project Euler [http://projecteuler.net/problem=6](http://projecteuler.net/problem=6)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -1,0 +1,82 @@
+# Etl
+
+We are going to do the `Transform` step of an Extract-Transform-Load.
+
+### ETL
+Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
+we're going to migrate this."
+
+(Typically, this is followed by, "We're only going to need to run this
+once." That's then typically followed by much forehead slapping and
+moaning about how stupid we could possibly be.)
+
+### The goal
+We're going to extract some scrabble scores from a legacy system.
+
+The old system stored a list of letters per score:
+
+- 1 point: "A", "E", "I", "O", "U", "L", "N", "R", "S", "T",
+- 2 points: "D", "G",
+- 3 points: "B", "C", "M", "P",
+- 4 points: "F", "H", "V", "W", "Y",
+- 5 points: "K",
+- 8 points: "J", "X",
+- 10 points: "Q", "Z",
+
+The shiny new scrabble system instead stores the score per letter, which
+makes it much faster and easier to calculate the score for a word. It
+also stores the letters in lower-case regardless of the case of the
+input letters:
+
+- "a" is worth 1 point.
+- "b" is worth 3 points.
+- "c" is worth 3 points.
+- "d" is worth 2 points.
+- Etc.
+
+Your mission, should you choose to accept it, is to transform the legacy data
+format to the shiny new format.
+
+### Notes
+
+A final note about scoring, Scrabble is played around the world in a
+variety of languages, each with its own unique scoring table. For
+example, an "E" is scored at 2 in the Māori-language version of the
+game while being scored at 4 in the Hawaiian-language version.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -1,0 +1,42 @@
+# Gigasecond
+
+Calculate the moment when someone has lived for 10^9 seconds.
+
+A gigasecond is 10^9 (1,000,000,000) seconds.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+Chapter 9 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=09](http://pine.fm/LearnToProgram/?Chapter=09)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -1,0 +1,73 @@
+# Hamming
+
+Calculate the Hamming difference between two DNA strands.
+
+A mutation is simply a mistake that occurs during the creation or
+copying of a nucleic acid, in particular DNA. Because nucleic acids are
+vital to cellular functions, mutations tend to cause a ripple effect
+throughout the cell. Although mutations are technically mistakes, a very
+rare mutation may equip the cell with a beneficial attribute. In fact,
+the macro effects of evolution are attributable by the accumulated
+result of beneficial microscopic mutations over many generations.
+
+The simplest and most common type of nucleic acid mutation is a point
+mutation, which replaces one base with another at a single nucleotide.
+
+By counting the number of differences between two homologous DNA strands
+taken from different genomes with a common ancestor, we get a measure of
+the minimum number of point mutations that could have occurred on the
+evolutionary path between the two strands.
+
+This is called the 'Hamming distance'.
+
+It is found by comparing two DNA strands and counting how many of the
+nucleotides are different from their equivalent in the other string.
+
+    GAGCCTACTAACGGGAT
+    CATCGTAATGACGGCCT
+    ^ ^ ^  ^ ^    ^^
+
+The Hamming distance between these two DNA strands is 7.
+
+# Implementation notes
+
+The Hamming distance is only defined for sequences of equal length. This means
+that based on the definition, each language could deal with getting sequences
+of equal length differently.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -1,0 +1,52 @@
+# Hello World
+
+The classical introductory exercise. Just say "Hello, World!".
+
+["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
+the traditional first program for beginning programming in a new language
+or environment.
+
+The objectives are simple:
+
+- Write a function that returns the string "Hello, World!".
+- Run the test suite and make sure that it succeeds.
+- Submit your solution and check it at the website.
+
+If everything goes well, you will be ready to fetch your first real exercise.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+This is an exercise to introduce users to using Exercism [http://en.wikipedia.org/wiki/%22Hello,_world!%22_program](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -1,0 +1,64 @@
+# Leap
+
+Given a year, report if it is a leap year.
+
+The tricky thing here is that a leap year in the Gregorian calendar occurs:
+
+```plain
+on every year that is evenly divisible by 4
+  except every year that is evenly divisible by 100
+    unless the year is also evenly divisible by 400
+```
+
+For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
+year, but 2000 is.
+
+If your language provides a method in the standard library that does
+this look-up, pretend it doesn't exist and implement it yourself.
+
+## Notes
+
+Though our exercise adopts some very simple rules, there is more to
+learn!
+
+For a delightful, four minute explanation of the whole leap year
+phenomenon, go watch [this youtube video][video].
+
+[video]: http://www.youtube.com/watch?v=xX96xng7sAE
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+JavaRanch Cattle Drive, exercise 3 [http://www.javaranch.com/leap.jsp](http://www.javaranch.com/leap.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -1,0 +1,64 @@
+# Nucleotide Count
+
+Given a DNA string, compute how many times each nucleotide occurs in the string.
+
+DNA is represented by an alphabet of the following symbols: 'A', 'C',
+'G', and 'T'.
+
+Each symbol represents a nucleotide, which is a fancy name for the
+particular molecules that happen to make up a large part of DNA.
+
+Shortest intro to biochemistry EVAR:
+
+- twigs are to birds nests as
+- nucleotides are to DNA and RNA as
+- amino acids are to proteins as
+- sugar is to starch as
+- oh crap lipids
+
+I'm not going to talk about lipids because they're crazy complex.
+
+So back to nucleotides.
+
+DNA contains four types of them: adenine (`A`), cytosine (`C`), guanine
+(`G`), and thymine (`T`).
+
+RNA contains a slightly different set of nucleotides, but we don't care
+about that for now.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+The Calculating DNA Nucleotides_problem at Rosalind [http://rosalind.info/problems/dna/](http://rosalind.info/problems/dna/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -1,0 +1,46 @@
+# Pangram
+
+Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
+"every letter") is a sentence using every letter of the alphabet at least once.
+The best known English pangram is: 
+> The quick brown fox jumps over the lazy dog.
+
+The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
+insensitive. Input will not contain non-ASCII symbols.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Pangram](https://en.wikipedia.org/wiki/Pangram)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -1,0 +1,55 @@
+# Raindrops
+
+Convert a number to a string, the contents of which depend on the number's factors.
+
+- If the number has 3 as a factor, output 'Pling'.
+- If the number has 5 as a factor, output 'Plang'.
+- If the number has 7 as a factor, output 'Plong'.
+- If the number does not have 3, 5, or 7 as a factor,
+  just pass the number's digits straight through.
+
+## Examples
+
+- 28's factors are 1, 2, 4, **7**, 14, 28.
+  - In raindrop-speak, this would be a simple "Plong".
+- 30's factors are 1, 2, **3**, **5**, 6, 10, 15, 30.
+  - In raindrop-speak, this would be a "PlingPlang".
+- 34 has four factors: 1, 2, 17, and 34.
+  - In raindrop-speak, this would be "34".
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+A variation on a famous interview question intended to weed out potential candidates. [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -1,0 +1,50 @@
+# React
+
+Implement a basic reactive system.
+
+Reactive programming is a programming paradigm that focuses on how values
+are computed in terms of each other to allow a change to one value to
+automatically propagate to other values, like in a spreadsheet.
+
+Implement a basic reactive system with cells with settable values ("input"
+cells) and cells with values computed in terms of other cells ("compute"
+cells). Implement updates so that when an input value is changed, values
+propagate to reach a new stable system state.
+
+In addition, compute cells should allow for registering change notification
+callbacks.  Call a cell’s callbacks when the cell’s value in a new stable
+state has changed from the previous stable state.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -1,0 +1,56 @@
+# Rna Transcription
+
+Given a DNA strand, return its RNA complement (per RNA transcription).
+
+Both DNA and RNA strands are a sequence of nucleotides.
+
+The four nucleotides found in DNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and thymine (**T**).
+
+The four nucleotides found in RNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and uracil (**U**).
+
+Given a DNA strand, its transcribed RNA strand is formed by replacing
+each nucleotide with its complement:
+
+* `G` -> `C`
+* `C` -> `G`
+* `T` -> `A`
+* `A` -> `U`
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -1,0 +1,53 @@
+# Robot Name
+
+Manage robot factory settings.
+
+When robots come off the factory floor, they have no name.
+
+The first time you boot them up, a random name is generated in the format
+of two uppercase letters followed by three digits, such as RX837 or BC811.
+
+Every once in a while we need to reset a robot to its factory settings,
+which means that their name gets wiped. The next time you ask, it will
+respond with a new random name.
+
+The names must be random: they should not follow a predictable sequence.
+Random names means a risk of collisions. Your solution must ensure that
+every existing robot has a unique name.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+A debugging session with Paul Blackwell at gSchool. [http://gschool.it](http://gschool.it)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -1,0 +1,80 @@
+# Roman Numerals
+
+Write a function to convert from normal numbers to Roman Numerals.
+
+The Romans were a clever bunch. They conquered most of Europe and ruled
+it for hundreds of years. They invented concrete and straight roads and
+even bikinis. One thing they never discovered though was the number
+zero. This made writing and dating extensive histories of their exploits
+slightly more challenging, but the system of numbers they came up with
+is still in use today. For example the BBC uses Roman numerals to date
+their programmes.
+
+The Romans wrote numbers using letters - I, V, X, L, C, D, M. (notice
+these letters have lots of straight lines and are hence easy to hack
+into stone tablets).
+
+```
+ 1  => I
+10  => X
+ 7  => VII
+```
+
+There is no need to be able to convert numbers larger than about 3000.
+(The Romans themselves didn't tend to go any higher)
+
+Wikipedia says: Modern Roman numerals ... are written by expressing each
+digit separately starting with the left most digit and skipping any
+digit with a value of zero.
+
+To see this in practice, consider the example of 1990.
+
+In Roman numerals 1990 is MCMXC:
+
+1000=M
+900=CM
+90=XC
+
+2008 is written as MMVIII:
+
+2000=MM
+8=VIII
+
+See also: http://www.novaroma.org/via_romana/numbers.html
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+The Roman Numeral Kata [http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -1,0 +1,58 @@
+# Series
+
+Given a string of digits, output all the contiguous substrings of length `n` in
+that string.
+
+For example, the string "49142" has the following 3-digit series:
+
+- 491
+- 914
+- 142
+
+And the following 4-digit series:
+
+- 4914
+- 9142
+
+And if you ask for a 6-digit series from a 5-digit string, you deserve
+whatever you get.
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+A subset of the Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -1,0 +1,57 @@
+# Triangle
+
+Determine if a triangle is equilateral, isosceles, or scalene.
+
+An _equilateral_ triangle has all three sides the same length.<br/>
+An _isosceles_ triangle has at least two sides the same length. (It is sometimes
+specified as having exactly two sides the same length, but for the purposes of
+this exercise we'll say at least two.)<br/>
+A _scalene_ triangle has all sides of different lengths.
+
+## Note
+
+For a shape to be a triangle at all, all sides have to be of length > 0, and 
+the sum of the lengths of any two sides must be greater than or equal to the 
+length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+
+## Dig Deeper
+
+The case where the sum of the lengths of two sides _equals_ that of the 
+third is known as a _degenerate_ triangle - it has zero area and looks like 
+a single line. Feel free to add your own code/tests to check for degenerate triangles.
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/dlang) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+The Ruby Koans triangle project, parts 1 & 2 [http://rubykoans.com](http://rubykoans.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
We are working towards making exercises stand-alone. That is to say: no more generating READMEs on the fly.

This will give maintainers more control over each individual exercise README, and it will also make some of the backend logic for delivering exercises simpler.

The README template uses the Go text/template package, and the default templates generate the same READMEs as we have been generating on the fly.  See the documentation in [regenerating exercise readmes][regenerate-docs] for details.

The READMEs can be generated at any time using a new 'generate' command in configlet. This command has not yet landed in master or been released, but can be built from source in the generate-readmes branch on [configlet][].

[configlet]: https://github.com/exercism/configlet
[regenerate-docs]: https://github.com/exercism/docs/blob/master/maintaining-a-track/regenerating-exercise-readmes.md

See https://github.com/exercism/meta/issues/15