### PR TITLE
Fix Travis CI builds

### DIFF
--- a/exercises/crypto-square/.dub/dub.json
+++ b/exercises/crypto-square/.dub/dub.json
@@ -1,0 +1,6 @@
+{
+	"dub": {
+		"lastUpgrade": "2017-09-04T18:03:23.938275",
+		"cachedUpgrades": {}
+	}
+}

--- a/exercises/crypto-square/example/crypto_square.d
+++ b/exercises/crypto-square/example/crypto_square.d
@@ -7,6 +7,8 @@ import std.math : sqrt, floor, ceil;
 import std.conv : to;
 
 import std.stdio;
+import std.algorithm : map, filter;
+import std.ascii : isAlphaNum;
 
 
 class Cipher
@@ -14,7 +16,7 @@ class Cipher
 public:
 	this (const string text)
 	{
-		this.normalized =  toLower(text.removechars(" `#$%^&.,<>:;'!~-?*@()[]{}_=|/\t\a\n\"+"));
+		this.normalized = text.filter!isAlphaNum.map!toLower.to!string;
 	}
 
 	string normalizePlainText ()
@@ -65,7 +67,7 @@ public:
 	{
 		string result = normalizedCipherText();
 
-		return result.removechars(" ");
+		return result.replace(" ", "");
 	}
 
 	string normalizedCipherText ()


### PR DESCRIPTION
Fixes #49.

The build failed because of the deprecation warnings. They aren't a big deal unless `
buildRequirements "disallowDeprecations"` is specified in the `dub.sdl` and this is exactly what happened.

I don't know why such option is in `dub.sdl`, because a lot of stuff in the D's standard library get deprecated and builds will continue failing for "no reason".