### PR TITLE
Adds resistor-color exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -296,6 +296,17 @@
         "floating_point_numbers",
         "math"
       ]
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "975c6fb4-f447-42ee-a1df-62ea9ac5a011",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "arrays",
+        "strings"
+      ]
     }
   ]
 }

--- a/exercises/resistor-color/README.md
+++ b/exercises/resistor-color/README.md
@@ -1,0 +1,57 @@
+# Resistor Color
+
+Resistors have color coded bands, where each color maps to a number. The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+
+These colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
+
+More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article](https://en.wikipedia.org/wiki/Electronic_color_code)
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/d) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+Maud de Vries, Erik Schierboom [https://github.com/exercism/problem-specifications/issues/1458](https://github.com/exercism/problem-specifications/issues/1458)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/resistor-color/dub.sdl
+++ b/exercises/resistor-color/dub.sdl
@@ -1,0 +1,2 @@
+name "resistor-color"
+buildRequirements "disallowDeprecations"

--- a/exercises/resistor-color/example/resistor_color.d
+++ b/exercises/resistor-color/example/resistor_color.d
@@ -1,0 +1,27 @@
+module resistor_color;
+
+import std.algorithm.searching : countUntil;
+
+class ResistorColor
+{
+    static immutable colors = [
+        "black", "brown", "red", "orange", "yellow", "green", "blue", "violet",
+        "grey", "white"
+    ];
+
+    static pure long colorCode(immutable string color)
+    {
+        return this.colors.countUntil(color);
+    }
+}
+
+unittest
+{
+    assert(ResistorColor.colorCode("black") == 0);
+    assert(ResistorColor.colorCode("white") == 9);
+    assert(ResistorColor.colorCode("orange") == 3);
+    assert(ResistorColor.colors == [
+            "black", "brown", "red", "orange", "yellow", "green", "blue",
+            "violet", "grey", "white"
+            ]);
+}

--- a/exercises/resistor-color/source/resistor_color.d
+++ b/exercises/resistor-color/source/resistor_color.d
@@ -1,0 +1,25 @@
+module resistor_color;
+
+unittest
+{
+    immutable int allTestsEnabled = 0;
+
+    // Black
+    assert(ResistorColor.colorCode("black") == 0);
+
+    static if (allTestsEnabled)
+    {
+        // White
+        assert(ResistorColor.colorCode("white") == 9);
+
+        // Orange
+        assert(ResistorColor.colorCode("orange") == 3);
+
+        // Colors
+        assert(ResistorColor.colors == [
+                "black", "brown", "red", "orange", "yellow", "green", "blue",
+                "violet", "grey", "white"
+                ]);
+    }
+
+}


### PR DESCRIPTION
Hi, this PR is to add the `resistor-color` exercise based off the [problem-specifications](https://github.com/exercism/problem-specifications/tree/master/exercises/resistor-color).

I'm still learning D, so please feel free to point out any changes to make this better.

Thanks!