### PR TITLE
Adds resistor-color-duo exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -307,6 +307,17 @@
         "arrays",
         "strings"
       ]
+    },
+    {
+      "slug": "resistor-color-duo",
+      "uuid": "6fd7d4dd-7473-4530-a3dc-892be4321efb",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "arrays",
+        "transforming"
+      ]
     }
   ]
 }

--- a/exercises/resistor-color-duo/README.md
+++ b/exercises/resistor-color-duo/README.md
@@ -1,0 +1,59 @@
+# Resistor Color Duo
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_. For this exercise, you need to know two things about them:
+
+* Each resistor has a resistance value.
+* Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+
+In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take two colors as input, and output the correct number.
+
+The band colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/d) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+Maud de Vries, Erik Schierboom [https://github.com/exercism/problem-specifications/issues/1464](https://github.com/exercism/problem-specifications/issues/1464)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/resistor-color-duo/dub.sdl
+++ b/exercises/resistor-color-duo/dub.sdl
@@ -1,0 +1,2 @@
+name "resistor-color-duo"
+buildRequirements "disallowDeprecations"

--- a/exercises/resistor-color-duo/example/resistor_color_duo.d
+++ b/exercises/resistor-color-duo/example/resistor_color_duo.d
@@ -1,0 +1,26 @@
+module resistor_color_duo;
+
+import std.algorithm.searching : countUntil;
+import std.algorithm.iteration;
+import std.conv;
+
+class ResistorColorDuo
+{
+    private static immutable colors = [
+        "black", "brown", "red", "orange", "yellow", "green", "blue", "violet",
+        "grey", "white"
+    ];
+
+    static pure long value(immutable string[] colorsInput)
+    {
+        return 10 * this.colors.countUntil(colorsInput[0]) + this.colors.countUntil(colorsInput[1]);
+    }
+}
+
+unittest
+{
+    assert(ResistorColorDuo.value(["brown", "black"]) == 10);
+    assert(ResistorColorDuo.value(["blue", "grey"]) == 68);
+    assert(ResistorColorDuo.value(["yellow", "violet"]) == 47);
+    assert(ResistorColorDuo.value(["orange", "orange"]) == 33);
+}

--- a/exercises/resistor-color-duo/source/resistor_color_duo.d
+++ b/exercises/resistor-color-duo/source/resistor_color_duo.d
@@ -1,0 +1,22 @@
+module resistor_color_duo;
+
+unittest
+{
+    const int allTestsEnabled = 0;
+
+    // Brown and black
+    assert(ResistorColorDuo.value(["brown", "black"]) == 10);
+
+    static if (allTestsEnabled)
+    {
+        // Blue and grey
+        assert(ResistorColorDuo.value(["blue", "grey"]) == 68);
+
+        // Yellow and violet
+        assert(ResistorColorDuo.value(["yellow", "violet"]) == 47);
+
+        // Orange and orange
+        assert(ResistorColorDuo.value(["orange", "orange"]) == 33);
+    }
+
+}


### PR DESCRIPTION
Hi, this PR is to add the `resistor-color-duo` exercise based off the [problem-specifications](https://github.com/exercism/problem-specifications/tree/master/exercises/resistor-color-duo).

I'm still learning D, so please feel free to point out any changes to make this better.

Thanks!