### PR TITLE
Adds run-length-encoding exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -213,6 +213,18 @@
         "nested_classes",
         "reactive_programming"
       ]
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "44d24e19-2600-469d-a405-d08d2a524b95",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "control_flow_if_statements",
+        "strings"
+      ]
     }
   ]
 }

--- a/exercises/rna-transcription/example/rna_transcription.d
+++ b/exercises/rna-transcription/example/rna_transcription.d
@@ -5,7 +5,7 @@ import std.string;
 
 immutable dchar[dchar] rnaTransTable;
 
-static this() {
+shared static this() {
  rnaTransTable = [
      'C': 'G',
      'G': 'C',

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -1,0 +1,61 @@
+# Run Length Encoding
+
+Implement run-length encoding and decoding.
+
+Run-length encoding (RLE) is a simple form of data compression, where runs
+(consecutive data elements) are replaced by just one data value and count.
+
+For example we can represent the original 53 characters with only 13.
+
+```text
+"WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"  ->  "12WB12W3B24WB"
+```
+
+RLE allows the original data to be perfectly reconstructed from
+the compressed data, which makes it a lossless data compression.
+
+```text
+"AABCCCDEEEE"  ->  "2AB3CD4E"  ->  "AABCCCDEEEE"
+```
+
+For simplicity, you can assume that the unencoded string will only contain
+the letters A through Z (either lower or upper case) and whitespace. This way
+data to be encoded will never contain any numbers and numbers inside data to
+be decoded always represent the count for the following character.
+
+## Getting Started
+
+Make sure you have read [D page](http://exercism.io/languages/d) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```D
+static if (all_tests_enabled)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard D facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [DRefLanguage](https://dlang.org/spec/spec.html)
+and [DReference](https://dlang.org/phobos/index.html) are references to the D language and D standard library.
+
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Run-length_encoding](https://en.wikipedia.org/wiki/Run-length_encoding)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/run-length-encoding/dub.sdl
+++ b/exercises/run-length-encoding/dub.sdl
@@ -1,0 +1,2 @@
+name "run-length-encoding"
+buildRequirements "disallowDeprecations"

--- a/exercises/run-length-encoding/example/run_length_encoding.d
+++ b/exercises/run-length-encoding/example/run_length_encoding.d
@@ -1,0 +1,69 @@
+module run_length_encoding;
+
+import std.algorithm : group;
+import std.array : array, join, empty, replicate;
+import std.algorithm.iteration : map;
+import std.format : format;
+import std.conv : to;
+
+pure string encode(immutable string input)
+{
+    string result;
+    auto grouping = input.array.group;
+    foreach (immutable dchar letter, immutable uint count; grouping)
+    {
+        if (count > 1)
+        {
+            result ~= "%d%s".format(count, letter);
+        }
+        else
+        {
+            result ~= letter;
+        }
+    }
+    return result;
+}
+
+pure string decode(immutable string input)
+{
+    string i, result;
+
+    foreach (immutable c; input) switch (c)
+    {
+    case '0': .. case '9':
+        i ~= c;
+        break;
+    default:
+        if (i.empty)
+        {
+            result ~= c;
+        }
+        else
+        {
+            result ~= [c].replicate(i.to!int);
+            i.length = 0;
+        }
+        break;
+    }
+
+    return result;
+}
+
+unittest
+{
+    assert(encode("") == "");
+    assert(encode("XYZ") == "XYZ");
+    assert(encode("AABBBCCCC") == "2A3B4C");
+    assert(encode("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB") == "12WB12W3B24WB");
+    assert(encode("  hsqq qww  ") == "2 hs2q q2w2 ");
+    assert(encode("aabbbcccc") == "2a3b4c");
+
+    assert(decode("") == "");
+    assert(decode("XYZ") == "XYZ");
+    assert(decode("2A3B4C") == "AABBBCCCC");
+    assert(decode("12WB12W3B24WB") == "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB");
+    assert(decode("2 hs2q q2w2 ") == "  hsqq qww  ");
+    assert(decode("2a3b4c") == "aabbbcccc");
+
+    assert("zzz ZZ  zZ".encode.decode == "zzz ZZ  zZ");
+}

--- a/exercises/run-length-encoding/source/run_length_encoding.d
+++ b/exercises/run-length-encoding/source/run_length_encoding.d
@@ -1,0 +1,54 @@
+module run_length_encoding;
+
+unittest
+{
+    immutable int allTestsEnabled = 0;
+
+    // run-length encode a string
+
+    // empty string
+    assert(encode("") == "");
+
+    static if (allTestsEnabled)
+    {
+        // single characters only are encoded without count
+        assert(encode("XYZ") == "XYZ");
+
+        // string with no single characters
+        assert(encode("AABBBCCCC") == "2A3B4C");
+
+        // single characters mixed with repeated characters
+        assert(encode("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB") == "12WB12W3B24WB");
+
+        // multiple whitespace mixed in string
+        assert(encode("  hsqq qww  ") == "2 hs2q q2w2 ");
+
+        // lowercase characters
+        assert(encode("aabbbcccc") == "2a3b4c");
+
+        // run-length decode a string
+
+        // empty string
+        assert(decode("") == "");
+
+        // string with no single characters
+        assert(decode("XYZ") == "XYZ");
+
+        // single characters with repeated characters
+        assert(decode("2A3B4C") == "AABBBCCCC");
+
+        // multiple whitespace mixed in string
+        assert(decode("12WB12W3B24WB") == "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB");
+
+        // multiple whitespace mixed in string
+        assert(decode("2 hs2q q2w2 ") == "  hsqq qww  ");
+
+        // lower case string
+        assert(decode("2a3b4c") == "aabbbcccc");
+
+        // encode and then decode
+
+        // encode followed by decode gives original string
+        assert("zzz ZZ  zZ".encode.decode == "zzz ZZ  zZ");
+    }
+}


### PR DESCRIPTION
Hi, this PR is to add the `run-length-encoding` exercise based off the [problem-specifications](https://github.com/exercism/problem-specifications/tree/master/exercises/run-length-encoding).

There is also a fix for the build due to an issue for deprecation warning in D v2.087.0

I'm still learning D, so please feel free to point out any changes to make this better.

Thanks!