### PR TITLE
Added typed parameters to function literals.

### DIFF
--- a/exercises/react/source/react.d
+++ b/exercises/react/source/react.d
@@ -23,7 +23,7 @@ static if (allTestsEnabled) {
     // compute cells calculate initial value
     Reactor!(int) r;
     auto input = r.new InputCell(1);
-    auto output = r.new ComputeCell(input, (x) => x + 1);
+    auto output = r.new ComputeCell(input, (int x) => x + 1);
 
     assert(output.value == 2);
   }
@@ -32,7 +32,7 @@ static if (allTestsEnabled) {
     Reactor!(int) r;
     auto one = r.new InputCell(1);
     auto two = r.new InputCell(2);
-    auto output = r.new ComputeCell(one, two, (x, y) => x + y * 10);
+    auto output = r.new ComputeCell(one, two, (int x, int y) => x + y * 10);
 
     assert(output.value == 21);
   }
@@ -40,7 +40,7 @@ static if (allTestsEnabled) {
     // compute cells update value when dependencies are changed
     Reactor!(int) r;
     auto input = r.new InputCell(1);
-    auto output = r.new ComputeCell(input, (x) => x + 1);
+    auto output = r.new ComputeCell(input, (int x) => x + 1);
 
     input.value = 3;
     assert(output.value == 4);
@@ -49,9 +49,9 @@ static if (allTestsEnabled) {
     // compute cells can depend on other compute cells
     Reactor!(int) r;
     auto input = r.new InputCell(1);
-    auto timesTwo = r.new ComputeCell(input, (x) => x * 2);
-    auto timesThirty = r.new ComputeCell(input, (x) => x * 30);
-    auto output = r.new ComputeCell(timesTwo, timesThirty, (x, y) => x + y);
+    auto timesTwo = r.new ComputeCell(input, (int x) => x * 2);
+    auto timesThirty = r.new ComputeCell(input, (int x) => x * 30);
+    auto output = r.new ComputeCell(timesTwo, timesThirty, (int x, int y) => x + y);
 
     assert(output.value == 32);
     input.value = 3;
@@ -61,7 +61,7 @@ static if (allTestsEnabled) {
     // compute cells fire callbacks
     Reactor!(int) r;
     auto input = r.new InputCell(1);
-    auto output = r.new ComputeCell(input, (x) => x + 1);
+    auto output = r.new ComputeCell(input, (int x) => x + 1);
     int[] vals;
 
     output.addCallback((int x) { vals ~= [x]; return; });
@@ -74,7 +74,7 @@ static if (allTestsEnabled) {
     // compute cells only fire on change
     Reactor!(int) r;
     auto input = r.new InputCell(1);
-    auto output = r.new ComputeCell(input, (x) => x < 3 ? 111 : 222);
+    auto output = r.new ComputeCell(input, (int x) => x < 3 ? 111 : 222);
     int[] vals;
 
     output.addCallback((int x) { vals ~= [x]; return; });
@@ -89,7 +89,7 @@ static if (allTestsEnabled) {
     // callbacks can be added and removed
     Reactor!(int) r;
     auto input = r.new InputCell(11);
-    auto output = r.new ComputeCell(input, (x) => x + 1);
+    auto output = r.new ComputeCell(input, (int x) => x + 1);
     int[] vals1;
     int[] vals2;
     int[] vals3;
@@ -116,7 +116,7 @@ static if (allTestsEnabled) {
     // removing a callback multiple times doesn't interfere with other callbacks
     Reactor!(int) r;
     auto input = r.new InputCell(1);
-    auto output = r.new ComputeCell(input, (x) => x + 1);
+    auto output = r.new ComputeCell(input, (int x) => x + 1);
     int[] vals1;
     int[] vals2;
 
@@ -137,10 +137,10 @@ static if (allTestsEnabled) {
     // callbacks should only be called once even if multiple dependencies change
     Reactor!(int) r;
     auto input = r.new InputCell(1);
-    auto plusOne = r.new ComputeCell(input, (x) => x + 1);
-    auto minusOne1 = r.new ComputeCell(input, (x) => x - 1);
-    auto minusOne2 = r.new ComputeCell(minusOne1, (x) => x - 1);
-    auto output = r.new ComputeCell(plusOne, minusOne2, (x, y) => x * y);
+    auto plusOne = r.new ComputeCell(input, (int x) => x + 1);
+    auto minusOne1 = r.new ComputeCell(input, (int x) => x - 1);
+    auto minusOne2 = r.new ComputeCell(minusOne1, (int x) => x - 1);
+    auto output = r.new ComputeCell(plusOne, minusOne2, (int x, int y) => x * y);
     int[] vals;
 
     output.addCallback((int x) { vals ~= [x]; return; });
@@ -154,9 +154,9 @@ static if (allTestsEnabled) {
     // callbacks should not be called if dependencies change but output value doesn't change
     Reactor!(int) r;
     auto input = r.new InputCell(1);
-    auto plusOne = r.new ComputeCell(input, (x) => x + 1);
-    auto minusOne = r.new ComputeCell(input, (x) => x - 1);
-    auto alwaysTwo = r.new ComputeCell(plusOne, minusOne, (x, y) => x - y);
+    auto plusOne = r.new ComputeCell(input, (int x) => x + 1);
+    auto minusOne = r.new ComputeCell(input, (int x) => x - 1);
+    auto alwaysTwo = r.new ComputeCell(plusOne, minusOne, (int x, int y) => x - y);
     int[] vals;
 
     alwaysTwo.addCallback((int x) { vals ~= [x]; return; });
@@ -175,12 +175,12 @@ static if (allTestsEnabled) {
     auto b = r.new InputCell(false);
     auto carryIn = r.new InputCell(false);
 
-    auto aXorB = r.new ComputeCell(a, b, (x, y) => x != y);
-    auto sum = r.new ComputeCell(aXorB, carryIn, (x, y) => x != y);
+    auto aXorB = r.new ComputeCell(a, b, (int x, int y) => x != y);
+    auto sum = r.new ComputeCell(aXorB, carryIn, (int x, int y) => x != y);
 
-    auto aXorBAndCin = r.new ComputeCell(aXorB, carryIn, (x, y) => x && y);
-    auto aAndB = r.new ComputeCell(a, b, (x, y) => x && y);
-    auto carryOut = r.new ComputeCell(aXorBAndCin, aAndB, (x, y) => x || y);
+    auto aXorBAndCin = r.new ComputeCell(aXorB, carryIn, (int x, int y) => x && y);
+    auto aAndB = r.new ComputeCell(a, b, (int x, int y) => x && y);
+    auto carryOut = r.new ComputeCell(aXorBAndCin, aAndB, (int x, int y) => x || y);
 
     bool[5][] tests = [
       //            inputs,     expected


### PR DESCRIPTION
The functions are currently templates. These are usually taken by alias templates in idiomatic D for the reasons below. 

You cannot - it may be possible, but not in a concise manner - do a generic solution to this problem, because the only way D can currently accept these functions is by manually providing overloads for delegates of specific arities. This is because the function, (say) x => x + 1, is actually a template (The type of which is void, which is not allowed in a D parameter pack). By providing a specific type annotation, these become function/delegate pointers, which can be part of a variadic template pack. Therefore, a generic solution is actually possible.