### PR TITLE
roman-numerals: rm untested example convertAlt

### DIFF
--- a/exercises/roman-numerals/example/roman_numerals.d
+++ b/exercises/roman-numerals/example/roman_numerals.d
@@ -22,24 +22,3 @@ string convert (ulong number)
 							.replace("LL", "C").replace("LXL", "XC").replace("CCCCC", "D")
 							.replace("CCCC", "CD").replace("DD", "M").replace("DCD", "CM");
 }
-
-// alternative implementation
-string convertAlt (ulong number)
-{
-	string[int] multiples = [
-							1000: "M", 900: "CM", 500: "D", 400: "CD",
-							100: "C", 90: "XC", 50: "L", 40: "XL", 10: "X",
-							9: "IX", 5: "V", 4: "IV", 1: "I"
-							];
-	string result = "".dup;
-	// the converison pairs need to be tried in descending order
-	auto pairs = multiples.byKeyValue.array;
-	pairs.sort!(q{a.key > b.key});
-	foreach (entry; pairs)
-	{
-		result ~= replicate(entry.value, number / entry.key);
-		number %= entry.key;
-	}
-
-	return result;
-}


### PR DESCRIPTION
Before https://github.com/exercism/d/pull/100, the example tested both
`convert` and `convertAlt`.
After that PR, instead the example only tests `convert`, leaving
`convertAlt` untested.

Leaving untested code in this repo runs the risk of the code going out
of date.

Delete the untested implementation. The goal of the track repo is not to
showcase a variety of working solutions; the track only need demonstrate
a single working solution.

Between `convert` and `convertAlt`, `convert` was arbitrarily chosen to
remain, so `convertAlt` is to be deleted.