### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [D](https://dlang.org) is a systems programming language with
 C-like syntax and static typing. It combines efficiency, control and modeling power with safety
 and programmer productivity. The language was developed originally by [Walter Bright](https://en.wikipedia.org/wiki/Walter_Bright) and [Andrei

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -6,24 +6,24 @@ installed on your system:
 * a D version 2 compiler
 * (optional but recommended) DUB
 
-### Prerequisite: D version 2 Compiler
+## Prerequisite: D version 2 Compiler
 
 On the D language's website [dlang.org](https://dlang.org) the most recent compiler
 version of the reference compiler DMD (Digital Mars D) can be downloaded and installed:
 
-#### Windows
+### Windows
 
 * [Installer](http://downloads.dlang.org/releases/2.x/2.071.1/dmd-2.071.1.exe)
 * or: [Archive](http://downloads.dlang.org/releases/2.x/2.071.1/dmd.2.071.1.windows.7z)
 * using [chocolatey](https://chocolatey.org/packages/dmd): choco install dmd
 
-#### Mac OS X
+### Mac OS X
 
 * .dmg [package](http://downloads.dlang.org/releases/2.x/2.071.0/dmd.2.071.0.dmg)
 * or: [Archive](http://downloads.dlang.org/releases/2.x/2.071.0/dmd.2.071.0.osx.tar.xz)
 * using [Homebrew](http://brew.sh/): brew install dmd
 
-#### Linux / FreeBSD
+### Linux / FreeBSD
 To quickly install dmd within your user directory, run: *curl -fsS https://dlang.org/install.sh | bash -s dmd*
 
 Packages for various distributions are provided:
@@ -34,7 +34,7 @@ Packages for various distributions are provided:
 * [Gentoo](https://wiki.gentoo.org/wiki/Dlang)
 * [OpenSuse](http://dlang.org/download.html#dmd)
 
-#### Other compilers
+### Other compilers
 Besides the DMD reference compiler which uses its own backend, there are two other compilers that can
 be fetched through the dlang.org download section:
 
@@ -46,7 +46,7 @@ support for other platforms like e.g. ARM.
 
 See the wiki for [more information](https://wiki.dlang.org/Compilers).
 
-#### IDE support
+### IDE support
 
 There are also support for the D language in various IDEs e.g.
 [VisualD](http://rainers.github.io/visuald/visuald/StartPage.html) for Visual Studio and

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,4 +1,4 @@
-## Prerequisites
+# Prerequisites
 
 The D language track requires that you have the following software
 installed on your system:

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 ## Learning D
 
 In general, exercism assumes you already know the syntax and mechanisms

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 
 * [Books](https://wiki.dlang.org/Books)
 * [Tutorials](https://wiki.dlang.org/Tutorials)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 
 Each exercise supplies the unit tests. You provide the implementation.
 Each file will produce a console executable that runs the tests. Running the test executable


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
