### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "a4ab17af-e1de-4fc3-9d62-d69de96731a6",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing D locally",
+      "blurb": "Learn how to install D locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "f6327a96-80be-4955-8cb5-ab989d1cfa9b",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn D",
+      "blurb": "An overview of how to get started from scratch with D"
+    },
+    {
+      "uuid": "d07cbfa5-9e48-4eb2-ac43-c0b68f7a5ebc",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the D track",
+      "blurb": "Learn how to test your D exercises on Exercism"
+    },
+    {
+      "uuid": "062bfc44-b4b0-407a-8e08-3396db8b7949",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful D resources",
+      "blurb": "A collection of useful resources to help you master D"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
