### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -474,32 +474,32 @@
     {
       "title": "Expressive",
       "content": "Support for multiple programming paradigms, with strong metaprogramming capabilities.",
-      "icon": ""
+      "icon": "expressive"
     },
     {
       "title": "Fast",
       "content": "D programs are compiled, leading to faster execution times than interpreted languages.",
-      "icon": ""
+      "icon": "fast"
     },
     {
       "title": "Safe",
       "content": "Functions tagged as @safe restrict them to a memory-safe subset of D.",
-      "icon": ""
+      "icon": "immutable"
     },
     {
       "title": "Language Interop",
       "content": "Seamlessly embed C and C++ into your D projects, giving you access to millions of libraries.",
-      "icon": ""
+      "icon": "interop"
     },
     {
       "title": "Better C",
       "content": "Integrate D into C projects using the -betterC compilation flag.",
-      "icon": ""
+      "icon": "powerful"
     },
     {
       "title": "Optional GC",
       "content": "Leave it enabled when it's needed, and disable it when it's not.",
-      "icon": ""
+      "icon": "garbage-collected"
     }
   ],
   "tags": [


### PR DESCRIPTION
The icons for key features are now available, and `configlet lint` now requires that each key feature has a valid `icon` value.

This PR sets an initial icon for each key feature - feel free to change them however you want. You can see the list of available icons [here](https://github.com/exercism/docs/issues/189). Note that an icon can be used regardless of its name.

With the initial state of this PR, the key features look something like the below.

---

![expressive](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/expressive.svg) Expressive
Support for multiple programming paradigms, with strong metaprogramming capabilities.

![fast](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/fast.svg) Fast
D programs are compiled, leading to faster execution times than interpreted languages.

![immutable](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/immutable.svg) Safe
Functions tagged as @safe restrict them to a memory-safe subset of D.

![interop](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/interop.svg) Language Interop
Seamlessly embed C and C++ into your D projects, giving you access to millions of libraries.

![powerful](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/powerful.svg) Better C
Integrate D into C projects using the -betterC compilation flag.

![garbage-collected](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/garbage-collected.svg) Optional GC
Leave it enabled when it's needed, and disable it when it's not.
