### PR TITLE
Sync triangle tests

### DIFF
--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -35,6 +35,8 @@ description = "isosceles triangle -> first and last sides are equal"
 
 [8d71e185-2bd7-4841-b7e1-71689a5491d8]
 description = "isosceles triangle -> equilateral triangles are also isosceles"
+include = false
+comment = "Current exercise implementation in D can't distinguish between equilateral and isosceles"
 
 [840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
 description = "isosceles triangle -> no sides are equal"
@@ -58,7 +60,13 @@ description = "scalene triangle -> no sides are equal"
 description = "scalene triangle -> all sides are equal"
 
 [c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
-description = "scalene triangle -> two sides are equal"
+description = "scalene triangle -> first and second sides are equal"
+
+[3da23a91-a166-419a-9abf-baf4868fd985]
+description = "scalene triangle -> first and third sides are equal"
+
+[b6a75d98-1fef-4c42-8e9a-9db854ba0a4d]
+description = "scalene triangle -> second and third sides are equal"
 
 [70ad5154-0033-48b7-af2c-b8d739cd9fdc]
 description = "scalene triangle -> may not violate triangle inequality"

--- a/exercises/practice/triangle/example/triangle.d
+++ b/exercises/practice/triangle/example/triangle.d
@@ -8,7 +8,7 @@ enum TriangleType
 };
 
 /**
- * Return what kind of triagle that is.
+ * Return what kind of triangle that is.
  */
 TriangleType kind(double a, double b, double c)
 {

--- a/exercises/practice/triangle/source/triangle.d
+++ b/exercises/practice/triangle/source/triangle.d
@@ -7,84 +7,113 @@ enum TriangleType
     scalene
 }
 
+TriangleType kind(double a, double b, double c)
+{
+    // Implement this function
+}
+
 unittest
 {
     import std.exception : assertThrown;
 
     immutable int allTestsEnabled = 0;
 
-    // equilateral_triangles_have_equal_sides
+    // equilateral triangle - all sides are equal
     {
         assert(TriangleType.equilateral == kind(2, 2, 2));
     }
 
     static if (allTestsEnabled)
     {
-        // larger_equilateral_triangles_also_have_equal_sides
+        // equilateral triangle - any side is uneven
         {
-            assert(TriangleType.equilateral == kind(10, 10, 10));
+            assert(TriangleType.equilateral != kind(2, 3, 2));
         }
 
-        // isosceles_triangles_have_last_two_sides_equal
+        // equilateral triangle - no sides are equal
+        {
+            assert(TriangleType.equilateral != kind(5, 4, 6));
+        }
+        
+        // equilateral triangle - all zero sides is not a triangle
+        {
+            assertThrown(kind(0, 0, 0));
+        }
+        
+        // equilateral triangle - sides may be floats
+        {
+            assert(TriangleType.equilateral == kind(0.5, 0.5, 0.5));
+        }
+
+        // isosceles triangle - last two sides are equal
         {
             assert(TriangleType.isosceles == kind(3, 4, 4));
         }
 
-        // isosceles_triangles_have_first_and_last_sides_equal
+        // isosceles triangle - first and last sides are equal
         {
             assert(TriangleType.isosceles == kind(4, 3, 4));
         }
 
-        // isosceles_triangles_have_first_two_sides_equal
+        //  isosceles triangle - no sides are equal
         {
-            assert(TriangleType.isosceles == kind(4, 4, 3));
+            assert(TriangleType.isosceles != kind(2, 3, 4));
         }
 
-        // isosceles_triangles_have_in_fact_exactly_two_sides_equal
-        {
-            assert(TriangleType.isosceles == kind(10, 10, 2));
-        }
-
-        // scalene_triangles_have_no_equal_sides
-        {
-            assert(TriangleType.scalene == kind(3, 4, 5));
-        }
-
-        // scalene_triangles_have_no_equal_sides_at_a_larger_scale_too
-        {
-            assert(TriangleType.scalene == kind(10, 11, 12));
-        }
-
-        // scalene_triangles_have_no_equal_sides_in_descending_order_either
-        {
-            assert(TriangleType.scalene == kind(5, 4, 2));
-        }
-
-        // very_small_triangles_are_legal
-        {
-            assert(TriangleType.scalene == kind(0.4, 0.6, 0.3));
-        }
-
-        // triangles_with_no_size_are_illegal
-        {
-            assertThrown(kind(0, 0, 0));
-        }
-
-        // triangles_with_negative_sides_are_illegal
-        {
-            assertThrown(kind(3, 4, -5));
-        }
-
-        // triangles_violating_triangle_inequality_are_illegal
+        // isosceles triangle - first triangle inequality violation
         {
             assertThrown(kind(1, 1, 3));
         }
 
-        // larger_triangles_violating_triangle_inequality_are_illegal
+        // isosceles triangle - second triangle inequality violation
+        {
+            assertThrown(kind(1, 3, 1));
+        }
+
+        // isosceles triangle - third triangle inequality violation
+        {
+            assertThrown(kind(3, 1, 1));
+        }
+
+        // isosceles triangle - sides may be floats
+        {
+            assert(TriangleType.isosceles == kind(0.5, 0.4, 0.5));
+        }
+
+        // scalene triangle - no sides are equal
+        {
+            assert(TriangleType.scalene == kind(5, 4, 6));
+        }
+
+        // scalene triangle - all sides are equal
+        {
+            assert(TriangleType.scalene != kind(4, 4, 4));
+        }
+
+        // scalene triangle - first and second sides are equal
+        {
+            assert(TriangleType.scalene != kind(4, 4, 3));
+        }
+
+        // scalene triangle - first and third sides are equal
+        {
+            assert(TriangleType.scalene != kind(3, 4, 3));
+        }
+
+        // scalene triangle - second and third sides are equal
+        {
+            assert(TriangleType.scalene != kind(4, 3, 3));
+        }
+
+        // scalene triangle - may not volate triangle inequality
         {
             assertThrown(kind(7, 3, 2));
         }
 
+        // scalene triangle - sides may be floats
+        {
+            assert(TriangleType.scalene == kind(0.5, 0.4, 0.6));
+        }
     }
 
 }


### PR DESCRIPTION
I noticed two tests were missing according to configlet sync, but in fact several tests were not present. Due to the exercise setup, I couldn't implement "equilateral triangles are also isosceles" without breaking 23 community solutions so that was excluded. Finally, I added a stub for the kind function to the student's file.