### PR TITLE
Make allTestsEnabled typing consistent

### DIFF
--- a/exercises/practice/pangram/source/pangram.d
+++ b/exercises/practice/pangram/source/pangram.d
@@ -2,7 +2,7 @@ module pangram;
 
 unittest
 {
-    immutable bool allTestsEnabled = false;
+    immutable int allTestsEnabled = 0;
 
     // Empty sentence
     assert(!isPangram(""));

--- a/exercises/practice/prime-factors/source/prime_factors.d
+++ b/exercises/practice/prime-factors/source/prime_factors.d
@@ -2,7 +2,7 @@ module prime_factors;
 
 unittest
 {
-    immutable bool allTestsEnabled = false;
+    immutable int allTestsEnabled = 0;
 
     // No factors
     assert(factors(1) == []);


### PR DESCRIPTION
37 of the exercises use an int for allTestsEnabled, and that's what the test runner also expects when it enables all tests to be run.