### PR TITLE
knapsack - struct literals

### DIFF
--- a/exercises/practice/knapsack/source/knapsack.d
+++ b/exercises/practice/knapsack/source/knapsack.d
@@ -9,7 +9,6 @@ uint maximumValue(Item[] items, uint maximumWeight)
 {
     // implement this function
 }
-
 unittest
 {
     immutable int allTestsEnabled = 0;
@@ -26,7 +25,7 @@ unittest
         // One item, too heavy
         {
             Item[] items = [
-                Item(weight: 100, value: 1),
+                Item(100, 1),
             ];
             assert(maximumValue(items, 10) == 0);
         }
@@ -34,11 +33,11 @@ unittest
         // Five items (cannot be greedy by weight)
         {
             Item[] items = [
-                Item(weight: 2, value: 5),
-                Item(weight: 2, value: 5),
-                Item(weight: 2, value: 5),
-                Item(weight: 2, value: 5),
-                Item(weight: 10, value: 21),
+                Item(2, 5),
+                Item(2, 5),
+                Item(2, 5),
+                Item(2, 5),
+                Item(10, 21),
             ];
             assert(maximumValue(items, 10) == 21);
         }
@@ -46,11 +45,11 @@ unittest
         // Five items (cannot be greedy by value)
         {
             Item[] items = [
-                Item(weight: 2, value: 20),
-                Item(weight: 2, value: 20),
-                Item(weight: 2, value: 20),
-                Item(weight: 2, value: 20),
-                Item(weight: 10, value: 50),
+                Item(2, 20),
+                Item(2, 20),
+                Item(2, 20),
+                Item(2, 20),
+                Item(10, 50),
             ];
             assert(maximumValue(items, 10) == 80);
         }
@@ -58,10 +57,10 @@ unittest
         // Example knapsack
         {
             Item[] items = [
-                Item(weight: 5, value: 10),
-                Item(weight: 4, value: 40),
-                Item(weight: 6, value: 30),
-                Item(weight: 4, value: 50),
+                Item(5, 10),
+                Item(4, 40),
+                Item(6, 30),
+                Item(4, 50),
             ];
             assert(maximumValue(items, 10) == 90);
         }
@@ -69,14 +68,14 @@ unittest
         // 8 items
         {
             Item[] items = [
-                Item(weight: 25, value: 350),
-                Item(weight: 35, value: 400),
-                Item(weight: 45, value: 450),
-                Item(weight: 5, value: 20),
-                Item(weight: 25, value: 70),
-                Item(weight: 3, value: 8),
-                Item(weight: 2, value: 5),
-                Item(weight: 2, value: 5),
+                Item(25, 350),
+                Item(35, 400),
+                Item(45, 450),
+                Item(5, 20),
+                Item(25, 70),
+                Item(3, 8),
+                Item(2, 5),
+                Item(2, 5),
             ];
             assert(maximumValue(items, 104) == 900);
         }
@@ -84,21 +83,21 @@ unittest
         // 15 items
         {
             Item[] items = [
-                Item(weight: 70, value: 135),
-                Item(weight: 73, value: 139),
-                Item(weight: 77, value: 149),
-                Item(weight: 80, value: 150),
-                Item(weight: 82, value: 156),
-                Item(weight: 87, value: 163),
-                Item(weight: 90, value: 173),
-                Item(weight: 94, value: 184),
-                Item(weight: 98, value: 192),
-                Item(weight: 106, value: 201),
-                Item(weight: 110, value: 210),
-                Item(weight: 113, value: 214),
-                Item(weight: 115, value: 221),
-                Item(weight: 118, value: 229),
-                Item(weight: 120, value: 240),
+                Item(70, 135),
+                Item(73, 139),
+                Item(77, 149),
+                Item(80, 150),
+                Item(82, 156),
+                Item(87, 163),
+                Item(90, 173),
+                Item(94, 184),
+                Item(98, 192),
+                Item(106, 201),
+                Item(110, 210),
+                Item(113, 214),
+                Item(115, 221),
+                Item(118, 229),
+                Item(120, 240),
             ];
             assert(maximumValue(items, 750) == 1458);
         }


### PR DESCRIPTION
Our struct literals for the Items no longer specify field names. This avoids test compilation
errors when students submit solutions.

https://dlang.org/spec/struct.html#struct-literal