### PR TITLE
Add verify-exercises-in-docker script

### DIFF
--- a/bin/verify-exercises-in-docker
+++ b/bin/verify-exercises-in-docker
@@ -40,23 +40,22 @@ splice_example_with_tests() {
 }
 
 pull_docker_image() {
-    docker pull "${image}" ||
-        die $'Could not find the `'"${image}"$'` Docker image.\nCheck the test runner docs at https://exercism.org/docs/building/tooling/test-runners for more information.'
+    local msg
+    # shellcheck disable=SC2016  # %s is a printf format specifier, not a shell expansion
+    printf -v msg 'Could not find the `%s` Docker image.\nCheck the test runner docs at https://exercism.org/docs/building/tooling/test-runners for more information.' "${image}"
+    docker pull "${image}" || die "${msg}"
 }
 
 run_tests() {
     local slug
     slug="${1}"
 
-    docker run \
-        --rm \
-        --network none \
-        --read-only \
-        --mount type=bind,src="${PWD}",dst=/solution \
-        --mount type=bind,src="${PWD}",dst=/output \
-        --mount type=tmpfs,dst=/tmp \
-        --mount type=tmpfs,dst=/root \
-        "${image}" "${slug}" /solution /output
+    local -a docker_args
+    docker_args+=(--rm --network none --read-only)
+    docker_args+=(--mount "type=bind,src=${PWD},dst=/solution")
+    docker_args+=(--mount "type=bind,src=${PWD},dst=/output")
+    docker_args+=(--mount "type=tmpfs,dst=/tmp" --mount "type=tmpfs,dst=/root")
+    docker run "${docker_args[@]}" "${image}" "${slug}" /solution /output
     jq -e '.status == "pass"' "${PWD}/results.json" >/dev/null 2>&1
 }
 
@@ -71,7 +70,7 @@ verify_exercise() {
     echo "Verifying ${slug} exercise..."
 
     (
-        trap 'rm -rf "$tmp_dir"' EXIT    # remove tempdir when subshell ends
+        trap 'rm -rf "${tmp_dir}"' EXIT    # remove tempdir when subshell ends
         cp -r "${dir}/." "${tmp_dir}"
         cd "${tmp_dir}"
 
@@ -85,19 +84,20 @@ verify_exercises() {
     exercise_slug="${1}"
 
     shopt -s nullglob
-    count=0
-    for exercise_dir in ./exercises/{concept,practice}/${exercise_slug}/; do
-        if [[ -d "${exercise_dir}" ]]; then
-            verify_exercise "${exercise_dir}"
-            ((++count))
-        fi
+    # shellcheck disable=SC2206  # intentional glob expansion
+    exercises=(./exercises/{concept,practice}/${exercise_slug}/)
+    local count=0
+    for exercise_dir in "${exercises[@]}"; do
+        [[ -d "${exercise_dir}" ]] || continue
+        verify_exercise "${exercise_dir}"
+        ((++count))
     done
     ((count > 0)) || die 'no matching exercises found!'
 }
 
 image=''
 while getopts :i: opt; do
-    case $opt in
+    case "${opt}" in
         i) image=$OPTARG ;;
         ?) echo >&2 "Unknown option: -$OPTARG"; exit 1 ;;
     esac
@@ -109,5 +109,8 @@ if [[ -z "${image}" ]]; then
     pull_docker_image
 fi
 
-exercise_slug="${1:-*}"
-verify_exercises "${exercise_slug}"
+if [[ -z "${1:-}" ]]; then
+    verify_exercises '*'
+else
+    verify_exercises "$1"
+fi

--- a/bin/verify-exercises-in-docker
+++ b/bin/verify-exercises-in-docker
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# Synopsis:
+# Verify that each exercise's example/exemplar solution passes the tests
+# using the track's test runner Docker image.
+# You can either verify all exercises or a single exercise.
+
+# Example: verify all exercises in Docker
+# bin/verify-exercises-in-docker
+
+# Example: verify single exercise in Docker
+# bin/verify-exercises-in-docker two-fer
+
+set -eo pipefail
+
+die() { echo "$*" >&2; exit 1; }
+
+required_tool() {
+    command -v "${1}" >/dev/null 2>&1 ||
+        die "${1} is required but not installed. Please install it and make sure it's in your PATH."
+}
+
+required_tool docker
+
+splice_example_with_tests() {
+    local src example
+    src=$(jq -r '.files.solution[0]' .meta/config.json)
+    example=$(jq -r '.files.example[0]' .meta/config.json)
+
+    {
+        cat "$example"
+        sed -nE '
+            /unittest/,$ {
+                s/(int allTestsEnabled =).*/\1 1;/
+                p
+            }
+        ' "$src"
+    } > "${src}.tmp"
+    mv "${src}.tmp" "$src"
+}
+
+pull_docker_image() {
+    docker pull "${image}" ||
+        die $'Could not find the `'"${image}"$'` Docker image.\nCheck the test runner docs at https://exercism.org/docs/building/tooling/test-runners for more information.'
+}
+
+run_tests() {
+    local slug
+    slug="${1}"
+
+    docker run \
+        --rm \
+        --network none \
+        --read-only \
+        --mount type=bind,src="${PWD}",dst=/solution \
+        --mount type=bind,src="${PWD}",dst=/output \
+        --mount type=tmpfs,dst=/tmp \
+        --mount type=tmpfs,dst=/root \
+        "${image}" "${slug}" /solution /output
+    jq -e '.status == "pass"' "${PWD}/results.json" >/dev/null 2>&1
+}
+
+verify_exercise() {
+    local dir
+    local slug
+    local tmp_dir
+    dir=$(realpath "${1}")
+    slug=$(basename "${dir}")
+    tmp_dir=$(mktemp -d -t "exercism-verify-${slug}-XXXXX")
+
+    echo "Verifying ${slug} exercise..."
+
+    (
+        trap 'rm -rf "$tmp_dir"' EXIT    # remove tempdir when subshell ends
+        cp -r "${dir}/." "${tmp_dir}"
+        cd "${tmp_dir}"
+
+        splice_example_with_tests
+        run_tests "${slug}" || { cat "${PWD}/results.json"; exit 1; }
+    )
+}
+
+verify_exercises() {
+    local exercise_slug
+    exercise_slug="${1}"
+
+    shopt -s nullglob
+    count=0
+    for exercise_dir in ./exercises/{concept,practice}/${exercise_slug}/; do
+        if [[ -d "${exercise_dir}" ]]; then
+            verify_exercise "${exercise_dir}"
+            ((++count))
+        fi
+    done
+    ((count > 0)) || die 'no matching exercises found!'
+}
+
+image=''
+while getopts :i: opt; do
+    case $opt in
+        i) image=$OPTARG ;;
+        ?) echo >&2 "Unknown option: -$OPTARG"; exit 1 ;;
+    esac
+done
+shift "$((OPTIND - 1))"
+
+if [[ -z "${image}" ]]; then
+    image="exercism/d-test-runner"
+    pull_docker_image
+fi
+
+exercise_slug="${1:-*}"
+verify_exercises "${exercise_slug}"


### PR DESCRIPTION
This useful script from generic-track tests exercise(s) against the test runner.

Like [bin/test-exercise](https://github.com/exercism/d/blob/main/bin/test-exercise),
we splice the exercise's example solution with the unittest block from the source.
